### PR TITLE
docs: add project related links

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "description": "The Blueprint for Your Next Big Idea",
   "author": "devsantara",
   "license": "MIT",
+  "homepage": "https://github.com/devsantara/kit#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/devsantara/kit.git"
+  },
+  "bugs": {
+    "url": "https://github.com/devsantara/kit/issues"
+  },
   "type": "module",
   "packageManager": "pnpm@10.12.2",
   "keywords": [


### PR DESCRIPTION
This pull request adds metadata to the `package.json` file to provide more information about the project and improve its discoverability.

Metadata additions:

* Added a `homepage` field pointing to the project's README on GitHub.
* Added a `repository` field specifying the type and URL of the project's Git repository.
* Added a `bugs` field with a URL for reporting issues on GitHub.