### PR TITLE
fix(eslint): invalid disable js typechecked rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -147,7 +147,8 @@ const eslintTypescriptConfig = [
     // (and you have javascript files in your project)
     name: '[Typescript] Disable javascript TypeChecked',
     files: ['**/*.{js,mjs,cjs,jsx}'],
-    ...eslintTypescriptPlugin.disableTypeChecked,
+    languageOptions: eslintTypescriptPlugin.configs.disableTypeChecked.languageOptions,
+    rules: eslintTypescriptPlugin.configs.disableTypeChecked.rules,
   },
   {
     name: '[Typescript] For definition files (.d.ts)',


### PR DESCRIPTION
This pull request updates the `eslint.config.js` file to improve the configuration for TypeScript linting. The change modifies the `eslintTypescriptConfig` object to directly reference `languageOptions` and `rules` from the `disableTypeChecked` configuration in `eslintTypescriptPlugin`.

### TypeScript linting configuration:

* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L150-R151): Replaced the spread operator with explicit references to `languageOptions` and `rules` from `eslintTypescriptPlugin.configs.disableTypeChecked` for better clarity and maintainability.