### PR TITLE
chore(eslint): add eslint restricted syntax rules for react import

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -323,6 +323,34 @@ const eslintNextConfig = [
   },
 ];
 
+const restrictedSyntaxReactImport = [
+  {
+    message: 'Do not import default from React. Use a namespace `import * as React from \'react\'` instead.',
+    selector: 'ImportDeclaration[source.value="react"] ImportDefaultSpecifier',
+  },
+  {
+    message: 'Please import React using `import * as React from \'react\'` instead of named imports.',
+    selector: 'ImportDeclaration[source.value=\'react\'] ImportSpecifier',
+  },
+  {
+    message: 'Please import React using namespace `React` (case sensitive) `import * as React from \'react\'` instead of others.',
+    selector: 'ImportDeclaration[source.value=\'react\'] ImportNamespaceSpecifier:not([local.name=\'React\'])',
+  },
+];
+
+const eslintRestrictedSyntaxConfig = [
+  {
+    name: '[Restricted Syntax] Base',
+    files: ['**/*.{js,mjs,cjs,jsx}', '**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        ...restrictedSyntaxReactImport,
+      ],
+    },
+  },
+];
+
 /**
  * @see {@link https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file}
  * @type {import('eslint').Linter.Config}
@@ -338,6 +366,7 @@ const eslintConfig = eslintTypescriptPlugin.config(
   ...eslintReactHooksConfig,
   ...eslintJsxA11yConfig,
   ...eslintNextConfig,
+  ...eslintRestrictedSyntaxConfig,
 );
 
 export default eslintConfig;


### PR DESCRIPTION
This pull request updates the ESLint configuration in `eslint.config.js` to enforce stricter rules for importing React. It introduces a new set of restricted syntax rules to ensure consistent and recommended import patterns for React across the codebase.

### ESLint Configuration Enhancements:

* **Restricted Syntax Rules for React Imports**:
  - Added rules to prohibit default imports from React (`import React from 'react'`) and enforce namespace imports (`import * as React from 'react'`).
  - Restricted named imports (`import { Component } from 'react'`) and ensured that namespace imports use the exact name `React` (case-sensitive).

* **Integration of Restricted Syntax Rules**:
  - Integrated the new `eslintRestrictedSyntaxConfig` into the main ESLint configuration (`eslintConfig`) to apply these rules globally.