### PR TITLE
chore(eslint): strict use of function declarations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -105,6 +105,7 @@ const eslintJavascriptConfig = [
     files: ['**/*.{js,mjs,cjs,jsx}', '**/*.{ts,tsx}'],
     rules: {
       ...eslintJsPlugin.configs.recommended.rules,
+      'func-style': ['error', 'declaration', { allowArrowFunctions: false }],
       'no-console': [
         'warn',
         {


### PR DESCRIPTION
This pull request introduces a small enhancement to the `eslint.config.js` file. It adds a new rule to enforce function declarations over arrow functions, improving code consistency and readability.

* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839R108): Added the `'func-style'` rule to enforce function declarations instead of arrow functions