### PR TITLE
fix(windows): unable to run sh scripts directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "release:major": "release-it major"
   },
   "dependencies": {
+    "jiti": "^2.4.2",
     "next": "^15.3.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint:inspect": "eslint --inspect-config",
     "format": "prettier --write .",
     "commitlint": "commitlint --edit",
-    "postinstall": "./scripts/postinstall.sh",
+    "postinstall": "jiti ./scripts/postinstall.ts",
     "release:patch": "release-it patch",
     "release:minor": "release-it minor",
     "release:major": "release-it major"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      jiti:
+        specifier: ^2.4.2
+        version: 2.4.2
       next:
         specifier: ^15.3.4
         version: 15.3.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Run husky install in non-production environments
-# When running in production, we don't install devDependencies
-if [ -d './node_modules/husky' ]; then
-  husky
-fi

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,13 +1,12 @@
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
 
-const HUSKY_DIRECTORY = './node_modules/husky';
-const HUSKY_INSTALL_COMMAND = 'husky';
+const isProduction = process.env.NODE_ENV === 'production';
+const isCI = process.env.CI === 'true';
 
 /**
- * Run husky install in non-production environments.
- * When running in production, we don't install devDependencies
+ * Skip Husky install in production and CI
+ * @see {@link https://typicode.github.io/husky/how-to.html#ci-server-and-docker}
  */
-if (existsSync(HUSKY_DIRECTORY)) {
-  execSync(HUSKY_INSTALL_COMMAND, { stdio: 'inherit' });
+if (!isProduction && !isCI) {
+  execSync('husky', { stdio: 'inherit' });
 }

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,0 +1,13 @@
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+const HUSKY_DIRECTORY = './node_modules/husky';
+const HUSKY_INSTALL_COMMAND = 'husky';
+
+/**
+ * Run husky install in non-production environments.
+ * When running in production, we don't install devDependencies
+ */
+if (existsSync(HUSKY_DIRECTORY)) {
+  execSync(HUSKY_INSTALL_COMMAND, { stdio: 'inherit' });
+}


### PR DESCRIPTION
This pull request updates the post-installation script from a shell script to a TypeScript file, improving maintainability and compatibility with Node.js environments. It also modifies the `package.json` file to reflect this change.

**Post-installation script migration:**

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R34): Updated the `postinstall` script to use `jiti` to execute the new TypeScript file `postinstall.ts` instead of the removed shell script `postinstall.sh`.
* [`scripts/postinstall.sh`](diffhunk://#diff-fb07e43d29bff868985b89fef043fa58deb0abe6c26e835cad51a09dfca86ef7L1-L7): Removed the shell script previously used for post-installation tasks.
* [`scripts/postinstall.ts`](diffhunk://#diff-4f6f6e58aa2ce2bf60b27890aa5f99d6eb824f4f3d59f1b101bcce144b66d2ebR1-R13): Added a new TypeScript script that checks for the presence of the `husky` directory and runs the `husky` installation command in non-production environments.