### PR TITLE
fix(eslint): error when import external package

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -177,7 +177,7 @@ const eslintTypescriptConfig: ConfigWithExtends[] = [
 const eslintImportConfig: ConfigWithExtends[] = [
   {
     name: '[Import] Base',
-    files: ['**/*.{js,mjs,jsx,ts,tsx}'],
+    files: ['**/*.{js,mjs,cjs,jsx}', '**/*.{ts,tsx}'],
     languageOptions: {
       // Override the recommended configs
       ecmaVersion: 'latest',
@@ -185,8 +185,10 @@ const eslintImportConfig: ConfigWithExtends[] = [
     },
     settings: {
       'import/resolver': {
-        node: true,
-        typescript: true,
+        'typescript': true,
+        'node': {
+          extensions: ['.js', '.ts', '.jsx', '.tsx', '.d.ts'],
+        },
       },
     },
     extends: [
@@ -198,7 +200,7 @@ const eslintImportConfig: ConfigWithExtends[] = [
       'import/newline-after-import': ['error', { count: 1 }],
       'import/no-absolute-path': ['error'],
       'import/no-duplicates': ['error', { 'prefer-inline': true }],
-      'import/no-cycle': ['error'],
+      'import/no-cycle': ['error', { ignoreExternal: true }],
       'import/no-self-import': ['error'],
       'import/no-named-as-default-member': ['off'],
       'import/order': [


### PR DESCRIPTION
## Issues
Unable to resolve path to module 'geist/font/sans'.eslintimport/no-unresolved and cycle import

## Summary
This pull request updates the ESLint configuration in `eslint.config.ts` to improve compatibility and enhance import rules. The changes include adjustments to file matching patterns, resolver settings, and rule configurations.

### Updates to ESLint Configuration:

#### File Matching Patterns:
* Modified the `files` property to separate JavaScript file patterns (`**/*.{js,mjs,cjs,jsx}`) from TypeScript file patterns (`**/*.{ts,tsx}`), ensuring more precise handling of file types.

#### Resolver Settings:
* Updated the `import/resolver` settings to specify extensions for the `node` resolver (`.js`, `.ts`, `.jsx`, `.tsx`, `.d.ts`) while retaining TypeScript support. This improves module resolution for both JavaScript and TypeScript files.

#### Import Rules:
* Enhanced the `import/no-cycle` rule by adding the `ignoreExternal: true` option, which excludes external dependencies from cycle detection, reducing false positives.