### PR TITLE
fix(eslint): excessive strictness level on types

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -138,8 +138,8 @@ const eslintTypescriptConfig: ConfigWithExtends[] = [
       },
     },
     extends: [
-      ...eslintTypescriptPlugin.configs.strictTypeChecked,
-      ...eslintTypescriptPlugin.configs.stylisticTypeChecked,
+      ...eslintTypescriptPlugin.configs.strict,
+      ...eslintTypescriptPlugin.configs.stylistic,
     ],
     rules: {
       '@typescript-eslint/no-unused-vars': [
@@ -283,6 +283,7 @@ const eslintReactConfig: ConfigWithExtends[] = [
     rules: {
       ...eslintReactPlugin.configs.recommended.rules,
       ...eslintReactPlugin.configs['jsx-runtime'].rules,
+      'react/prop-types': ['off'],
       'react/jsx-no-leaked-render': ['error'],
       'react/function-component-definition': [
         'error',


### PR DESCRIPTION
This pull request updates the ESLint configuration to streamline type-checking settings and adjust React-specific rules. The most important changes include switching to less strict type-checking presets and disabling the `react/prop-types` rule.

### Updates to TypeScript ESLint Configuration:
* [`eslint.config.ts`](diffhunk://#diff-3202509a51dddde1968b20a04dfcedc90615eb6681cca0cda5f43a418a516857L141-R142): Replaced `strictTypeChecked` and `stylisticTypeChecked` presets with `strict` and `stylistic` presets for TypeScript ESLint configurations. This simplifies the configuration by using less strict presets.

### Updates to React ESLint Configuration:
* [`eslint.config.ts`](diffhunk://#diff-3202509a51dddde1968b20a04dfcedc90615eb6681cca0cda5f43a418a516857R286): Disabled the `react/prop-types` rule to align with modern React practices, as PropTypes are less commonly used in TypeScript projects.