### PR TITLE
chore(linter): check types with tsc

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -17,6 +17,11 @@ function buildEslintCommand(stagedFiles) {
   return `eslint --cache --fix ${stagedFiles.join(' ')}`;
 }
 
+// Type check with TypeScript
+function buildTypeCheckCommand() {
+  return 'tsc --noEmit';
+}
+
 /**
  * Lint staged files
  * @description Run commands on staged files based on their types
@@ -30,7 +35,7 @@ const lintStagedConfig = {
     return [buildEslintCommand(stagedFiles)];
   },
   [TYPESCRIPT_FILES]: function (stagedFiles) {
-    return [buildEslintCommand(stagedFiles)];
+    return [buildTypeCheckCommand(), buildEslintCommand(stagedFiles)];
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint --cache",
+    "lint:ts": "tsc --noEmit",
     "lint:fix": "eslint --cache --fix",
     "lint:inspect": "eslint --inspect-config"
   },


### PR DESCRIPTION
This pull request enhances the linting workflow for TypeScript files by adding a TypeScript type-checking step alongside ESLint, ensuring that type errors are caught early during pre-commit checks. It also adds a new npm script for running type checks manually.

**Linting and Type Checking Improvements:**

* Added a `buildTypeCheckCommand` function to run `tsc --noEmit` for type checking TypeScript files (`lint-staged.config.js`).
* Updated the lint-staged configuration to run both type checking and ESLint on staged TypeScript files, improving code quality assurance before commits (`lint-staged.config.js`).

**NPM Scripts:**

* Added a new `lint:ts` script to `package.json` to allow manual execution of TypeScript type checking.